### PR TITLE
scripts can now handle multiple trajectory files of the same system

### DIFF
--- a/cdf_generation_MD.py
+++ b/cdf_generation_MD.py
@@ -15,12 +15,12 @@ def parseArguments():
     parser.add_argument('-trj',
                         dest='trajectory',
                         required=True,
-                        help='[Required] The path of the topology file',
-                        nargs=1)
+                        help='[Required] The path of the trajectory file, can also handle multiple trajectories of the same system',
+                        nargs="*")
     parser.add_argument('-top',
                         dest='topology',
                         required=True,
-                        help='[Required] The path of the trajectory file',
+                        help='[Required] The path of the topology file',
                         nargs=1)
     parser.add_argument('-n',
                         dest='cdf_name',
@@ -43,11 +43,11 @@ def parseArguments():
 if __name__ == '__main__':
     args = parseArguments()
 
-    trajectory = args.trajectory[0]
+    trajectory = args.trajectory
     topology = args.topology[0]
 
     if args.cdf_name is None:
-        cdf_name = os.path.basename(trajectory)[:-4]
+        cdf_name = os.path.basename(trajectory[0])[:-4]
     else:
         cdf_name = args.cdf_name[0]
 

--- a/get_interaction_map.py
+++ b/get_interaction_map.py
@@ -18,11 +18,11 @@ def parseArguments():
                         dest='trajectory',
                         required=True,
                         help='[Required] The path of the topology file',
-                        nargs=1)
+                        nargs="*")
     parser.add_argument('-top',
                         dest='topology',
                         required=True,
-                        help='[Required] The path of the trajectory file',
+                        help='[Required] The path of the trajectory file, can also handle multiple trajectories of the same system',
                         nargs=1)
     parser.add_argument('-lig',
                         dest='ligand_code',
@@ -52,9 +52,9 @@ if __name__ == '__main__':
     args = parseArguments()
 
     initial_time = time.time()
-    trajectory = args.trajectory[0]
+    trajectory = args.trajectory
     topology = args.topology[0]
-    name = os.path.basename(trajectory)[:-4]
+    name = os.path.basename(trajectory[0])[:-4]
     ligand_code = args.ligand_code[0]
    
     if args.chunk_size is None:


### PR DESCRIPTION
A very simple suggested change to allow multipe trajectory files of the same system.

MDAnalysis is used in the background, therefore it can handle a list of trajectories natively and argparse parses multiple inputs in a list. To change as little as possible, the default name was changed to the first entry of said list excluding the file extensions.